### PR TITLE
change etch to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Create Etch components from functions that take props and return JSX",
   "main": "dist/index.js",
   "scripts": {
-    "test": "npm run standard && node_modules/.bin/electron-mocha --renderer --recursive ./test/helpers/register-babel  test",
+    "test": "npm run standard && electron-mocha --renderer --recursive ./test/helpers/register-babel  test",
     "tdd": "npm run standard && node_modules/.bin/electron-mocha --renderer --interactive --recursive ./test/helpers/register-babel  test",
     "prepublish": "npm run standard && npm run clean && npm run build",
     "standard": "node_modules/.bin/standard --recursive src test",
@@ -24,12 +24,15 @@
     "url": "https://github.com/BinaryMuse/etch-stateless/issues"
   },
   "homepage": "https://github.com/BinaryMuse/etch-stateless",
+  "peerDependencies": {
+    "etch": ">= 0.12.2 < 1"
+  },
   "devDependencies": {
     "babel": "^5.0.0",
     "babel-eslint": "^4.0.5",
     "chai": "^2.0.0",
-    "electron-mocha": "git://github.com/nathansobo/electron-mocha.git#interactive-option",
-    "electron-prebuilt": "^0.30.1",
+    "electron-mocha": "^3.4.0",
+    "electron-prebuilt": "^1.4.13",
     "etch": "^0.5.0",
     "mocha": "^2.1.0",
     "standard": "^4.5.4"

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
-export default function stateless (etch, renderFn) {
-  if (typeof etch === 'function') {
-    throw new Error("The first parameter to stateless should be the Etch library")
-  }
+const etch = require('etch')
 
+export default function stateless (renderFn) {
   class EtchStateless {
     constructor (props, children) {
       this.props = props

--- a/test/unit/hook.test.js
+++ b/test/unit/hook.test.js
@@ -6,7 +6,7 @@ import stateless from '../../src/index'
 
 describe('etch.stateless(render)', () => {
   it('renders with props and children', () => {
-    let Component = stateless(etch, (props, children) => {
+    let Component = stateless((props, children) => {
       return <div>{children}{props.hello}</div>
     })
     let component = new Component({hello: " world"}, <span>Hello</span>)
@@ -15,20 +15,12 @@ describe('etch.stateless(render)', () => {
   })
 
   it('updates with new props and children', async () => {
-    let Component = stateless(etch, (props, children) => {
+    let Component = stateless((props, children) => {
       return <div>{children}{props.hello}</div>
     })
     let component = new Component({hello: " world"}, <span>Hello</span>)
     await component.update({hello: " Etch"}, <span>Howdy</span>)
 
     expect(component.element.textContent).to.equal('Howdy Etch')
-  })
-
-  describe('when the user forgets to pass etch as the first param', () => {
-    it('throws an error', () => {
-      expect(() => {
-        stateless(() => <div />)
-      }).to.throw()
-    })
   })
 })


### PR DESCRIPTION
Etch can be a peer dependency which will tell the user that etch is not available when installing without it.

With this it is known that etch is installed and it no longer needs passing as the first option to `stateless`.